### PR TITLE
Nuevo estado y busqueda con eso

### DIFF
--- a/src/const/order.const.ts
+++ b/src/const/order.const.ts
@@ -11,4 +11,5 @@ export const orderErrorsConst = {
   ERROR_CREATING_ORDER: 'Error Creating Order',
   ERROR_GETTING_ORDERS: 'Error getting orders',
   ERROR_EMPTY_COMMENT: 'Need to add a comment to cancel the order',
+  ERROR_UPDATE_PAYMENT: 'Error update the payment',
 };

--- a/src/enums/order-status.enum.ts
+++ b/src/enums/order-status.enum.ts
@@ -5,3 +5,8 @@ export enum OrderStatusEnum {
   DELIVERED = 'Delivered',
   CANCELED = 'Canceled',
 }
+
+export enum paymentStatus {
+  COMPLETED = 'Completed',
+  FAILED = 'Failed',
+}

--- a/src/modules/order/order.entity.ts
+++ b/src/modules/order/order.entity.ts
@@ -13,6 +13,7 @@ import { AddressEntity } from '../user-profile/address/address.entity';
 import { OrderCommentEntity } from './order-comment/order-comment.entity';
 import { OrderDetailEntity } from './order-detail/order-detail.entity';
 import { OrderStatusEntity } from './order-status/order-status.entity';
+import { paymentStatus } from 'src/enums/order-status.enum';
 
 @Entity({ name: 'order' })
 export class OrderEntity extends AbstractEntity {
@@ -45,6 +46,9 @@ export class OrderEntity extends AbstractEntity {
 
   @Column({ type: 'date', nullable: true })
   trackingDate: Date;
+
+  @Column({ type: 'enum', enum: paymentStatus, default: paymentStatus.FAILED })
+  paymentStatus: paymentStatus;
 
   @ManyToOne(() => OrderStatusEntity, (status) => status.orders)
   @JoinColumn()

--- a/src/modules/order/payment/payment.repository.ts
+++ b/src/modules/order/payment/payment.repository.ts
@@ -16,7 +16,7 @@ export class PaymentRepository extends Repository<PaymentEntity> {
     paymentMethod: PaymentMethodEnum,
   ): Promise<PaymentEntity> {
     const payment = this.create({
-      referenceId: paymentData.transactionId, 
+      referenceId: paymentData.transactionId,
       status: paymentData.transactionStatus,
       textCode: paymentData.textCode && paymentData.textCode,
       paymentMethod: paymentMethod,

--- a/src/modules/order/payment/payment.service.ts
+++ b/src/modules/order/payment/payment.service.ts
@@ -113,14 +113,11 @@ export class PaymentService implements PaymentServiceInterface {
     const billTo = new APIContracts.CustomerAddressType();
     billTo.setFirstName(user.userProfile.name);
     billTo.setLastName(user.userProfile.lastName);
-    // billTo.setCompany('Vware');
     billTo.setAddress(order.address.street);
     billTo.setCity(order.address.city);
     billTo.setState(order.address.state);
     billTo.setZip(order.address.zipCode);
-    // billTo.setCountry('Tecate');
     billTo.setPhoneNumber('12345667');
-    // billTo.setFaxNumber('12345');
     billTo.setEmail(user.username);
 
     const lineItemList = [];


### PR DESCRIPTION
Se hizo un nuevo estado a la orden de paymentStatus, que tiene como enum 'Completed' o 'Failed', de default esta como 'Failed' mediante esto en los querys de busqueda trae las ordenes que tenga nada mas 'Complete' y discrimina las 'Failed'